### PR TITLE
Update ghostwriter/shell to version 0.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require": {
         "php": "~8.4.0 || ~8.5.0",
         "ghostwriter/filesystem": "^0.1.2",
-        "ghostwriter/shell": "^0.1.1"
+        "ghostwriter/shell": "^0.1.2"
     },
     "require-dev": {
         "ext-xdebug": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7d1c853fd9bb07e825bcc898c389dc1",
+    "content-hash": "cdabbef90c1f98b5ea84e126b86bb6e8",
     "packages": [
         {
             "name": "ghostwriter/filesystem",
@@ -78,16 +78,16 @@
         },
         {
             "name": "ghostwriter/shell",
-            "version": "0.1.1",
+            "version": "0.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/shell.git",
-                "reference": "c50dccf80a93d257557de76cf25e6f2be7fbc3b9"
+                "reference": "e6367b96cd6be790291bc23c1e5d3aa607335109"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/shell/zipball/c50dccf80a93d257557de76cf25e6f2be7fbc3b9",
-                "reference": "c50dccf80a93d257557de76cf25e6f2be7fbc3b9",
+                "url": "https://api.github.com/repos/ghostwriter/shell/zipball/e6367b96cd6be790291bc23c1e5d3aa607335109",
+                "reference": "e6367b96cd6be790291bc23c1e5d3aa607335109",
                 "shasum": ""
             },
             "require": {
@@ -98,11 +98,15 @@
                 "ghostwriter/coding-standard": "dev-main",
                 "ghostwriter/container": "^6.0.1",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^12.4.4",
-                "symfony/var-dumper": "^7.3.5"
+                "phpunit/phpunit": "^12.5.7",
+                "symfony/var-dumper": "^8.0.3"
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/ghostwriter/shell",
+                    "name": "ghostwriter/shell"
+                },
                 "ghostwriter": {
                     "container": {
                         "definition": "Ghostwriter\\Shell\\Container\\ShellDefinition"
@@ -116,7 +120,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-4-Clause"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
@@ -145,7 +149,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-25T19:01:49+00:00"
+            "time": "2026-01-25T08:43:34+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Updates the `ghostwriter/shell` dependency from `0.1.1` to `0.1.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`