### PR TITLE
Update symfony/var-dumper to version 8.0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "mockery/mockery": "^1.6.12",
         "phpbench/phpbench": "^1.4.3",
         "phpunit/phpunit": "^13.0.5",
-        "symfony/var-dumper": "^8.0.4"
+        "symfony/var-dumper": "^8.0.6"
     },
     "prefer-stable": true,
     "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "60c331e867111e06c522de13f1467209",
+    "content-hash": "4f347aae81ce9ad41c555e7d86b52b42",
     "packages": [
         {
             "name": "ghostwriter/filesystem",
@@ -3496,16 +3496,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v8.0.4",
+            "version": "v8.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "326e0406fc315eca57ef5740fa4a280b7a068c82"
+                "reference": "2e14f7e0bf5ff02c6e63bd31cb8e4855a13d6209"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/326e0406fc315eca57ef5740fa4a280b7a068c82",
-                "reference": "326e0406fc315eca57ef5740fa4a280b7a068c82",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/2e14f7e0bf5ff02c6e63bd31cb8e4855a13d6209",
+                "reference": "2e14f7e0bf5ff02c6e63bd31cb8e4855a13d6209",
                 "shasum": ""
             },
             "require": {
@@ -3559,7 +3559,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v8.0.4"
+                "source": "https://github.com/symfony/var-dumper/tree/v8.0.6"
             },
             "funding": [
                 {
@@ -3579,7 +3579,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-01T23:07:29+00:00"
+            "time": "2026-02-15T10:53:29+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -3683,9 +3683,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "ghostwriter/coding-standard": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
Updates the `symfony/var-dumper` dependency from `v8.0.4` to `8.0.6`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`