### PR TITLE
Update phpbench/phpbench to version 1.5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require-dev": {
         "ext-xdebug": "*",
         "mockery/mockery": "^1.6.12",
-        "phpbench/phpbench": "^1.5.0",
+        "phpbench/phpbench": "^1.5.1",
         "phpunit/phpunit": "^13.0.5",
         "symfony/var-dumper": "^8.0.6"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de49917ff0f4753f7c6a4c23f5fefe85",
+    "content-hash": "08aa3e6958e57f3cc420fd0b3a2f6680",
     "packages": [
         {
             "name": "ghostwriter/filesystem",
@@ -730,16 +730,16 @@
         },
         {
             "name": "phpbench/phpbench",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpbench/phpbench.git",
-                "reference": "63e5a853b84ef27729b2af7f42365a19434fdc79"
+                "reference": "9a28fd0833f11171b949843c6fd663eb69b6d14c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/63e5a853b84ef27729b2af7f42365a19434fdc79",
-                "reference": "63e5a853b84ef27729b2af7f42365a19434fdc79",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/9a28fd0833f11171b949843c6fd663eb69b6d14c",
+                "reference": "9a28fd0833f11171b949843c6fd663eb69b6d14c",
                 "shasum": ""
             },
             "require": {
@@ -817,7 +817,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpbench/phpbench/issues",
-                "source": "https://github.com/phpbench/phpbench/tree/1.5.0"
+                "source": "https://github.com/phpbench/phpbench/tree/1.5.1"
             },
             "funding": [
                 {
@@ -825,7 +825,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-04T20:33:49+00:00"
+            "time": "2026-03-05T08:18:58+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3684,9 +3684,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "ghostwriter/coding-standard": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
Updates the `phpbench/phpbench` dependency from `1.5.0` to `1.5.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`